### PR TITLE
Added selector as optional parameter for grid init

### DIFF
--- a/js/grid.js
+++ b/js/grid.js
@@ -163,8 +163,10 @@ $.fn.imagesLoaded = function( callback ) {
 
 var Grid = (function() {
 
+		// grid selector
+		var $selector = '#og-grid', 
 		// list of items
-	var $grid = $( '#og-grid' ),
+		$grid = $( $selector ),
 		// the items
 		$items = $grid.children( 'li' ),
 		// current expanded item's index


### PR DESCRIPTION
Thumbnail grid can be attached to any "list" element on the page.
Two or more grids can be created on the same page.
