### PR TITLE
Changing .load() to .on('load') since .load() is deprecated in jquery v3

### DIFF
--- a/js/grid.js
+++ b/js/grid.js
@@ -405,9 +405,12 @@ var Grid = (function() {
 
 			// preload large image and add it to the preview
 			// for smaller screens we don´t display the large image (the media query will hide the fullimage wrapper)
+
+			// Changing .load() to .on('load') since .load() is deprecated in jquery version 3
+
 			if( self.$fullimage.is( ':visible' ) ) {
 				this.$loading.show();
-				$( '<img/>' ).load( function() {
+				$( '<img/>' ).on('load', function() {
 					var $img = $( this );
 					if( $img.attr( 'src' ) === self.$item.children('a').data( 'largesrc' ) ) {
 						self.$loading.hide();


### PR DESCRIPTION
Changing .load() to .on('load') since .load() is deprecated in jquery version 3